### PR TITLE
Add pack installation instructions

### DIFF
--- a/src/content/docs/using-pack/install-pack.md
+++ b/src/content/docs/using-pack/install-pack.md
@@ -31,7 +31,6 @@ From there, you can copy the executable to a directory like `/usr/local/bin` or 
 ```shell
 wget https://github.com/buildpack/pack/releases/download/v{{< latest >}}/pack-{{< latest >}}-linux.tar.gz
 tar xvf pack-{{< latest >}}-linux.tar.gz
-pack-{{< latest >}}-linux.tar.gz
 rm pack-{{< latest >}}-macos.tar.gz
 ./pack --help
 ```
@@ -41,3 +40,4 @@ From there, you can copy the executable to a directory like `/usr/local/bin` or 
 ## Windows
 
 You can install the Windows executable for `pack` by downloading the Windows [ZIP file](https://github.com/buildpack/pack/releases/download/v{{< latest >}}/pack-{{< latest >}}-windows.zip).
+

--- a/src/content/docs/using-pack/install-pack.md
+++ b/src/content/docs/using-pack/install-pack.md
@@ -20,7 +20,7 @@ To install `pack` on macOS, fetch and unpack the tarball:
 ```shell
 wget https://github.com/buildpack/pack/releases/download/v{{< latest >}}/pack-{{< latest >}}-macos.tar.gz
 tar xvf pack-{{< latest >}}-macos.tar.gz
-rm xvf pack-{{< latest >}}-macos.tar.gz
+rm pack-{{< latest >}}-macos.tar.gz
 ./pack --help
 ```
 
@@ -32,6 +32,7 @@ From there, you can copy the executable to a directory like `/usr/local/bin` or 
 wget https://github.com/buildpack/pack/releases/download/v{{< latest >}}/pack-{{< latest >}}-linux.tar.gz
 tar xvf pack-{{< latest >}}-linux.tar.gz
 pack-{{< latest >}}-linux.tar.gz
+rm pack-{{< latest >}}-macos.tar.gz
 ./pack --help
 ```
 

--- a/src/content/docs/using-pack/install-pack.md
+++ b/src/content/docs/using-pack/install-pack.md
@@ -1,0 +1,42 @@
++++
+title="Installing `pack`"
+weight=2
+creatordisplayname="Luc Perkins"
+creatoremail="lucperkins@gmail.com"
+lastmodifierdisplayname="Luc Perkins"
+lastmodifieremail="lucperkins@gmail.com"
++++
+
+You can install the most recent version of `pack` (version **{{< latest >}}**) as an executable binary on the following operating systems:
+
+* [macOS](#macos)
+* [Linux](#linux)
+* [Windows](#windows)
+
+## macOS
+
+To install `pack` on macOS, fetch and unpack the tarball:
+
+```shell
+wget https://github.com/buildpack/pack/releases/download/v{{< latest >}}/pack-{{< latest >}}-macos.tar.gz
+tar xvf pack-{{< latest >}}-macos.tar.gz
+rm xvf pack-{{< latest >}}-macos.tar.gz
+./pack --help
+```
+
+From there, you can copy the executable to a directory like `/usr/local/bin` or add the current directory to your `PATH`.
+
+## Linux
+
+```shell
+wget https://github.com/buildpack/pack/releases/download/v{{< latest >}}/pack-{{< latest >}}-linux.tar.gz
+tar xvf pack-{{< latest >}}-linux.tar.gz
+pack-{{< latest >}}-linux.tar.gz
+./pack --help
+```
+
+From there, you can copy the executable to a directory like `/usr/local/bin` or add the current directory to your `PATH`.
+
+## Windows
+
+You can install the Windows executable for `pack` by downloading the Windows [ZIP file](https://github.com/buildpack/pack/releases/download/v{{< latest >}}/pack-{{< latest >}}-windows.zip).

--- a/src/themes/buildpacks/layouts/shortcodes/latest.html
+++ b/src/themes/buildpacks/layouts/shortcodes/latest.html
@@ -1,0 +1,4 @@
+{{- $releasesUrl := "https://api.github.com/repos/buildpack/pack/releases" }}
+{{- $releases    := getJSON $releasesUrl }}
+{{- $latest      := (index $releases 0).tag_name | replace "v" "" }}
+{{- $latest -}}

--- a/src/themes/buildpacks/layouts/shortcodes/latest.html
+++ b/src/themes/buildpacks/layouts/shortcodes/latest.html
@@ -1,4 +1,5 @@
 {{- $releasesUrl := "https://api.github.com/repos/buildpack/pack/releases" }}
 {{- $releases    := getJSON $releasesUrl }}
-{{- $latest      := (index $releases 0).tag_name | replace "v" "" }}
+{{- $latestTag   := (index $releases 0).tag_name -}}
+{{- $latest      := replace $latestTag "v" "" -}}
 {{- $latest -}}


### PR DESCRIPTION
I sadly don't really have the chops to add Windows installation docs. I'll leave that as an exercise for others.

I also added a reusable shortcode that can infer the latest version using the GitHub Releases API.