### PR TITLE
Small correction on buildpack creation tutorial

### DIFF
--- a/content/docs/create-buildpack/build-app.md
+++ b/content/docs/create-buildpack/build-app.md
@@ -8,12 +8,12 @@ lastmodifieremail = "djoyce@pivotal.io"
 +++
 
 
-Next we will make the build step work.  This will require a few updates to the build script.
+Next we will make the build step work.  This will require a few updates to the `bin/build` file.
 
 We need to read the layers directory passed in by build lifecycle - learn more about the lifecycle [here](https://github.com/buildpack/lifecycle)
 
 ```
-layersdir=$1 
+layersdir=$1
 ```
 
 We need to create a ruby layer in the image. We'll add `launch = true` to direct the lifecycle to provide ruby when we launch our app.
@@ -30,7 +30,15 @@ ruby_url=https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-18/rub
 wget -q -O - "$ruby_url" | tar -xzf - -C "$layersdir/ruby"
 ```
 
+Make ruby accessible in this script
+
+```
+export PATH=$layersdir/ruby/bin:$PATH
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+${LD_LIBRARY_PATH}:}$layersdir/ruby/lib
+```
+
 Finally, we will need to install bundler and then run bundle install
+
 
 ```
 gem install bundler --no-ri --no-rdoc
@@ -38,7 +46,7 @@ bundle install
 ```
 
 
-Your build script will now look like this
+And now your `bin/build` script will look like this
 
 ```
 #!/usr/bin/env bash

--- a/content/docs/create-buildpack/building-blocks-cnb.md
+++ b/content/docs/create-buildpack/building-blocks-cnb.md
@@ -83,6 +83,16 @@ These two files are now executable detect and build scripts.  Now you can run yo
 
 In order to test your buildpack, you will need to run the buildpack against your sample ruby app using the `pack` cli.
 
+Set your default builder to either `cloudfoundry/cnb:cflinuxfs3` or `heroku/buildpacks:18` by running one of
+
+```
+pack set-default-builder cloudfoundry/cnb:cflinuxfs3
+```
+```
+pack set-default-builder heroku/buildpacks:18
+```
+
+
 Run the following pack command
 
 ```

--- a/content/docs/create-buildpack/caching.md
+++ b/content/docs/create-buildpack/caching.md
@@ -11,7 +11,7 @@ Next we want to separate the ruby interpreter and bundled gems into different la
 
 ### Creating the Bundler Layer
 
-To do this replace the line
+To do this replace the line in the `bin/build` script
 
 ```
 echo "---> Installing gems"
@@ -77,7 +77,7 @@ You will see the a similar line added during the EXPORTING phase
 
 Next we will start caching gem dependencies to help speed up the build if no new dependencies are needed.
 
-First, we'll need to install some helpful tools at the top of the build script
+First, we'll need to install some helpful tools at the top of the `bin/build` script
 
 ```
 # Download some useful tools

--- a/content/docs/create-buildpack/detection.md
+++ b/content/docs/create-buildpack/detection.md
@@ -8,16 +8,16 @@ lastmodifierdisplayname = "Danny Joyce"
 lastmodifieremail = "djoyce@pivotal.io"
 +++
 
-Next you will want to actually detect that the app your are building is a ruby app. In order to do this you will need to check for a Gemfile.
+Next you will want to actually detect that the app your are building is a ruby app. In order to do this you will need to check for a `Gemfile`.
 
-Replace `exit 1` with the following check in your detect script
+Replace `exit 1` in the `bin/detect` file with the following check
 
 ```
 if [[ ! -f Gemfile ]]; then
    exit 100
 fi
 ```
-And now your detect script will look like this
+And now your `bin/detect` script will look like this
 
 ```
 #!/usr/bin/env bash
@@ -52,7 +52,7 @@ You will see the following output
 ERROR: failed with status code: 7
 ```
 
-Notice that `detect` now passes because there is a valid Gemfile in the ruby app at `~/ruby-sample-app`, but now `build` fails because it is coded to do so.
+Notice that `detect` now passes because there is a valid `Gemfile` in the ruby app at `~/ruby-sample-app`, but now `build` fails because it is coded to do so.
 
 You will also notice `ANALYZING` now appears in the build output.  This steps is part of the buildpack lifecycle that looks to see if any previous image builds have layers that the buildpack can re-use. We will get into this topic in more detail later.
 

--- a/content/docs/create-buildpack/make-app-runnable.md
+++ b/content/docs/create-buildpack/make-app-runnable.md
@@ -7,16 +7,16 @@ lastmodifierdisplayname = "Danny Joyce"
 lastmodifieremail = "djoyce@pivotal.io"
 +++
 
-Next we want to set a default start command for the application in the image.  You will want to add the following code to then end of your build script. 
+Next we want to set a default start command for the application in the image.  You will want to add the following code to then end of your `bin/build` script.
 
 ```
 # Set default start command
-echo 'processes = [{ type = "web", command = ""bundle exec ruby app.rb""}]' > "$layersdir/launch.toml"
+echo 'processes = [{ type = "web", command = "bundle exec ruby app.rb"}]' > "$layersdir/launch.toml"
 ```
 
 This sets your default start command.
 
-Your full build script should now look like this
+Your full `bin/build` script should now look like this
 
 ```
 #!/usr/bin/env bash


### PR DESCRIPTION
- be more specific when referring to file to change
- add instruction to select a builder image
- PATH set up was not in the instructions but only in the final content
- fix double quote typo when making application runnable

We run through the tutorial and we found a few confusing things that we try to fix with this PR