### PR TITLE
Add --rm to `docker run` to clean up containers

### DIFF
--- a/content/docs/app-developer-guide/build-an-app.md
+++ b/content/docs/app-developer-guide/build-an-app.md
@@ -48,7 +48,7 @@ pack build sample-app --path samples/apps/java-maven/ --builder cnbs/sample-buil
 ### 3. Run it
 
 ```bash
-docker run -p 8080:8080 sample-app
+docker run --rm -p 8080:8080 sample-app
 ```
 
 **Congratulations!** 

--- a/content/docs/buildpack-author-guide/create-buildpack/make-app-runnable.md
+++ b/content/docs/buildpack-author-guide/create-buildpack/make-app-runnable.md
@@ -61,7 +61,7 @@ pack build test-ruby-app --path ~/workspace/ruby-sample-app --buildpack ~/worksp
 You should then be able to run your new Ruby app:
  
 ```bash
-docker run -p 8080:8080 test-ruby-app
+docker run --rm -p 8080:8080 test-ruby-app
 ```
 
 and see the server log output:

--- a/content/docs/operator-guide/create-a-builder.md
+++ b/content/docs/operator-guide/create-a-builder.md
@@ -87,7 +87,7 @@ didn't even use the app source code. What they did do was show the environment i
 the app image with `CNB_PROCESS_TYPE=sys-info` we can see the runtime information as well.
 
 ```bash
-docker run --env CNB_PROCESS_TYPE=sys-info -it my-app
+docker run --rm --env CNB_PROCESS_TYPE=sys-info -it my-app
 ```
 
 We're sure you'll be able to create more useful builders.


### PR DESCRIPTION
This commit adds `--rm` option to all `docker run` in this document. Probably few want to keep a container in tutorials.

Note:  [content/docs/app-journey.md](https://github.com/buildpack/docs/blob/b20a878167ce6fb821377c114bd016842c606d5e/content/docs/app-journey.md) uses `docker run --rm`.