### PR TITLE
Remove bionic builder from create buildpack tutorial

### DIFF
--- a/content/docs/buildpack-author-guide/create-buildpack/building-blocks-cnb.md
+++ b/content/docs/buildpack-author-guide/create-buildpack/building-blocks-cnb.md
@@ -34,9 +34,6 @@ name = "Ruby Buildpack"
 id = "heroku-18"
 
 [[stacks]]
-id = "io.buildpacks.stacks.bionic"
-
-[[stacks]]
 id = "org.cloudfoundry.stacks.cflinuxfs3"
 ```
 
@@ -89,9 +86,7 @@ Set your default builder by running one of the following:
 ```bash
 pack set-default-builder cloudfoundry/cnb:cflinuxfs3
 ```
-```bash
-pack set-default-builder cloudfoundry/cnb:bionic
-```
+
 ```bash
 pack set-default-builder heroku/buildpacks:18
 ```


### PR DESCRIPTION
As reported in #79 and #68, the bionic cloudfoundry builder `cnbs/sample-builder:bionic` does not currently work for our tutorial as it does not have `wget` installed.

_NOTE: This is an interim solution until we can further update our tutorials to use the sample builders._

Resolves #79
Resolves #68

Signed-off-by: Javier Romero <jromero@pivotal.io>