### PR TITLE
Add anchor links for headers

### DIFF
--- a/themes/buildpacks/assets/scss/components/_docs.scss
+++ b/themes/buildpacks/assets/scss/components/_docs.scss
@@ -71,6 +71,20 @@
       a {
         text-decoration: none;
         border-bottom: 1px solid rgba($blue-dark, 0.25);
+        &.h-anchor {
+          margin-left: -0.9em;
+          border-bottom: 0px;
+          i {
+            font-size: 0.7em;
+            visibility: hidden;
+            border-bottom: 0px;
+          }
+          &:hover {
+            i {
+              visibility: visible;
+            }
+          }
+        }
       }
     }
 

--- a/themes/buildpacks/layouts/_default/baseof.html
+++ b/themes/buildpacks/layouts/_default/baseof.html
@@ -18,6 +18,27 @@
       gtag('config', 'UA-124323167-1');
     </script>  */}}
 
+    <script>
+      function addAnchor(element) {
+        if (element.id === "" || element.getElementsByTagName("a").length > 0) {
+          return;
+        }
+
+        element.innerHTML =
+          `<a href="#${element.id}" class="h-anchor">
+            <i class="fas fa-link icon" ariaLabel="Anchor"></i> ${element.innerHTML}
+          </a>`;
+      }
+
+      document.addEventListener('DOMContentLoaded', function () {
+        var headers = document.querySelectorAll('h1, h2, h3, h4, h5');
+
+        if (headers) {
+          headers.forEach(addAnchor);
+        }
+      });
+    </script>
+
     <title>{{ .Title }} · {{ .Site.Title }}</title>
   </head>
   <body>


### PR DESCRIPTION
This adds links to all `h2`, `h3`, `h4` elements for anchor links as suggested in https://github.com/buildpack/docs/issues/65.

I _think_ this works, but locally the anchor links weren't anchoring to the correct locations, so it would be useful to test this on some sort of staging environment if that exists.