### PR TITLE
Bundler no longer fails when there are gem updates

### DIFF
--- a/content/docs/buildpack-author-guide/create-buildpack/make-buildpack-configurable.md
+++ b/content/docs/buildpack-author-guide/create-buildpack/make-buildpack-configurable.md
@@ -90,7 +90,7 @@ if [[ -f Gemfile.lock && $local_bundler_checksum == $remote_bundler_checksum ]] 
 else
     # Determine if there has been a gem dependency change and install new gems to the bundler layer; re-using existing and un-changed gems
     echo "---> Installing gems"
-    mkdir "$bundlerlayer"
+    mkdir "$bundlerlayer" || true
     echo -e "cache = true\nlaunch = true\nmetadata = \"$local_bundler_checksum\"" > "$bundlerlayer.toml"
     bundle install --path "$bundlerlayer" --binstubs "$bundlerlayer/bin"
 fi


### PR DESCRIPTION
The buildpack example breaks in the case it finds an existing gemfile, but the checksum doesn't match, so it fails to create the folder.

After adding `|| true`, it no longer fails to build.

Signed-off-by: Dan Acristinii <dan.acristinii@swisscom.com>

> _By signing off you acknowledge adhering to the requirements listed here: https://probot.github.io/apps/dco/_