### PR TITLE
Adding section to migrate and use OCI layout format

### DIFF
--- a/content/docs/reference/spec/migration/platform-api-0.11-0.12.md
+++ b/content/docs/reference/spec/migration/platform-api-0.11-0.12.md
@@ -73,11 +73,11 @@ The lifecycle phases affected by this new behavior are:
 - [Export](https://buildpacks.io/docs/concepts/components/lifecycle/export/)
 - [Create](https://buildpacks.io/docs/concepts/components/lifecycle/create/)
 
-**Note** [Rebase](https://buildpacks.io/docs/concepts/components/lifecycle/rebase/) an image exported to OCI layout format is not supported.
+**Note** [Rebasing](https://buildpacks.io/docs/concepts/components/lifecycle/rebase/) an image exported to OCI layout format is not supported.
 
 #### Before executing the lifecycle
 
-Input images required by any phase, like the `run-image` or `previous-image`, must be saved on disk in OCI layout format in the local storage previously defined following the 
+Input images required by any phase, like the `run-image` or `previous-image`, must be saved on disk in OCI layout format in the layout directory following the 
 [rules](https://github.com/buildpacks/spec/blob/platform/v0.12/platform.md#map-an-image-reference-to-a-path-in-the-layout-directory) to convert the reference to a path.
 
 #### During lifecycle execution


### PR DESCRIPTION
Adding documentation for using the new capability to export to OCI layout format, available on Platform 0.12