### PR TITLE
Use buildpacks-community GH org for kpack

### DIFF
--- a/content/docs/for-app-developers/concepts/platform.md
+++ b/content/docs/for-app-developers/concepts/platform.md
@@ -31,7 +31,7 @@ For the latest version of the Platform API, see [releases][releases] on the spec
 [builder]: /docs/for-app-developers/concepts/builder/
 [buildpack]: /docs/for-app-developers/concepts/buildpack/
 [buildpacks-tekton]: https://github.com/tektoncd/catalog/tree/master/task/buildpacks
-[kpack]: https://github.com/pivotal/kpack
+[kpack]: https://github.com/buildpacks-community/kpack
 [lifecycle]: /docs/for-platform-operators/concepts/lifecycle/
 [pack]: https://github.com/buildpacks/pack
 [releases]: https://github.com/buildpacks/spec/releases?q=platform

--- a/content/docs/for-platform-operators/how-to/integrate-ci/kpack.md
+++ b/content/docs/for-platform-operators/how-to/integrate-ci/kpack.md
@@ -45,10 +45,8 @@ kpack is also accompanied by a handy CLI utility called [kpack CLI][cli] that le
 - [kpack tutorial][tutorial]
 - [kpack Donation announcement] [announcement]
 
-[vmware]: https://www.vmware.com/company.html
-[vmware-tanzu]: https://tanzu.vmware.com/build-service
-[kpack]: https://github.com/pivotal/kpack
-[tutorial]: https://github.com/pivotal/kpack/blob/master/docs/tutorial.md
-[cli]: https://github.com/vmware-tanzu/kpack-cli/blob/master/docs/kp.md
+[kpack]: https://github.com/buildpacks-community/kpack
+[tutorial]: https://github.com/buildpacks-community/kpack/blob/main/docs/tutorial.md
+[cli]: https://github.com/buildpacks-community/kpack-cli/blob/main/docs/kp.md
 [buildpacks]: https://buildpacks.io
 [announcement]: https://medium.com/buildpacks/kpack-joins-the-buildpacks-community-organization-223e59bda951


### PR DESCRIPTION
I've corrected the kpack links to use the new buildpacks-community GH org.
In addition, I removed the references `[vmware]` and `[vmware-tanzu]` since they were not used.