### PR TITLE
Fix formatting of kpack Donation announcement link

### DIFF
--- a/content/docs/for-platform-operators/how-to/integrate-ci/kpack.md
+++ b/content/docs/for-platform-operators/how-to/integrate-ci/kpack.md
@@ -43,7 +43,7 @@ kpack is also accompanied by a handy CLI utility called [kpack CLI][cli] that le
 - [kpack GitHub repository][kpack]
 - [kpack CLI Github repository][cli]
 - [kpack tutorial][tutorial]
-- [kpack Donation announcement] [announcement]
+- [kpack Donation announcement][announcement]
 
 [kpack]: https://github.com/buildpacks-community/kpack
 [tutorial]: https://github.com/buildpacks-community/kpack/blob/main/docs/tutorial.md


### PR DESCRIPTION
May be pedantic, but the link wasn't being rendered correctly due to some annoying spacing issues.