### PR TITLE
set errata-ai/vale separator

### DIFF
--- a/.github/workflows/vale-lint.yml
+++ b/.github/workflows/vale-lint.yml
@@ -15,6 +15,7 @@ jobs:
         uses: tj-actions/changed-files@v41
         with:
           files: content/**/*.md  # Only check markdown files in the content directory
+          separator: ","
 
       - uses: errata-ai/vale-action@v2.1.1
         if: steps.changed-files.outputs.any_changed == 'true'
@@ -22,3 +23,4 @@ jobs:
           fail_on_error: true
           token: ${{secrets.GITHUB_TOKEN}}
           files: ${{ steps.changed-files.outputs.all_changed_files }}
+          separator: ","


### PR DESCRIPTION
The current vale action breaks when there is multiple files detected in the diff. You'll get the following warning:

> Warning: User-specified path (content/community.md content/docs/_index.md) is invalid; falling back to 'all'.

It then passes the files with a space separator, but the vale action doesn't know how to handle it unless you specify the separator. I've hardcoded a separator `,` for both the `changed-files` and the `vale-action` actions so they match.

This should fix the vale error in #882.