### PR TITLE
fix(nav): make mobile navbar toggle functional

### DIFF
--- a/themes/buildpacks/layouts/partials/header.html
+++ b/themes/buildpacks/layouts/partials/header.html
@@ -2,7 +2,7 @@
   <nav class="navbar navbar-expand-lg navbar-light">
     <a href="{{.Site.BaseURL}}" class="logo navbar-brand"><img src="/images/buildpacks-logo.svg"
         alt="Buildpacks Logo"></a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
       aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>


### PR DESCRIPTION
This PR fixes a bug where the mobile navigation menu toggle (hamburger menu) was non-responsive when clicked. The issue was preventing users on mobile devices or small screens from accessing the site's navigation.

## Related Issue
Fixes #887

## Screenshots
| Before | After |
| :--- | :--- |
| <img width="120" alt="fix-mobile-nav-toggle-before" src="https://github.com/user-attachments/assets/92a69a3d-ea89-457d-bce1-afa8828b0e99" /> | <img width="120" alt="fix-mobile-nav-toggle-after" src="https://github.com/user-attachments/assets/2ed15aef-8004-49cb-bc08-4510906eb26c" /> |

