### PR TITLE
fix(homepage): restore tab functionality for introduction videos

### DIFF
--- a/themes/buildpacks/layouts/index.html
+++ b/themes/buildpacks/layouts/index.html
@@ -35,20 +35,20 @@
           <div>
             <ul class="nav nav-pills flex-md-row justify-content-end">
               <li class="nav-item">
-                <a class="nav-link py-3 active" data-toggle="tab" href="#java-video">
+                <a class="nav-link py-3 active" data-bs-toggle="tab" data-bs-target="#java-video" role="tab">
                   <img width="40" height="40"
                     src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/java/java-original.svg" alt="Java" />
                 </a>
               </li>
               <li class="nav-item">
-                <a class="nav-link py-3" data-toggle="tab" href="#javascript-video">
+                <a class="nav-link py-3" data-bs-toggle="tab" data-bs-target="#javascript-video" role="tab">
                   <img width="40" height="40"
                     src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg"
                     alt="JavaScript" />
                 </a>
               </li>
               <li class="nav-item">
-                <a class="nav-link py-3" data-toggle="tab" href="#python-video">
+                <a class="nav-link py-3" data-bs-toggle="tab" data-bs-target="#python-video" role="tab">
                   <img width="40" height="40"
                     src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" alt="Python" />
                 </a>


### PR DESCRIPTION
The tabs for selecting the introduction video (Java, JavaScript, Python) on the homepage were not responding to clicks, preventing users from switching between them.

This PR restores the Bootstrap tab-switching functionality so that the tabs are interactive again.

**Screenshots:**
| Before | After |
| :--- | :--- |
| <img width="320" alt="fix-homepage-restore-tab-functionality-for-introduction-videos-before" src="https://github.com/user-attachments/assets/97211851-df05-406e-94b4-4e0e79ea2e80" /> | <img width="320" alt="fix-homepage-restore-tab-functionality-for-introduction-videos-after" src="https://github.com/user-attachments/assets/9e3c7212-4d56-4272-a420-df51d8d014f2" /> |
