### PR TITLE
docs: Fix ANSI escape sequences in pack CLI leaking into documentation

### DIFF
--- a/tools/get_pack_commands.go
+++ b/tools/get_pack_commands.go
@@ -7,12 +7,15 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/buildpacks/pack/cmd"
 	"github.com/buildpacks/pack/pkg/logging"
 	"github.com/spf13/cobra/doc"
 )
+
+var ansiEscape = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 
 const (
 	cliDir     = "/docs/for-platform-operators/how-to/integrate-ci/pack/cli/"
@@ -64,6 +67,27 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	if err := stripANSIFromDir(outputPath); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func stripANSIFromDir(dir string) error {
+	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || filepath.Ext(path) != ".md" {
+			return err
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		cleaned := ansiEscape.ReplaceAll(data, nil)
+		if len(cleaned) == len(data) {
+			return nil
+		}
+		return os.WriteFile(path, cleaned, info.Mode())
+	})
 }
 
 type packLogger struct {


### PR DESCRIPTION
## Fixes Issue

- Fixes #891

## Problem

The `get_pack_commands.go` generator uses `cobra/doc.GenMarkdownTreeCustom` to produce markdown from the pack command tree. Some pack commands include ANSI color codes in their description strings (e.g. `\x1b[94m...\x1b[0m`) to improve terminal --help readability. These codes were passing through the generator unmodified and appearing as noise in the rendered documentation. See #891 for screenshots of the three affected places in the documentation. Which are:

https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/cli/pack_config_pull-policy/
https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/cli/pack_config_lifecycle-image/
https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/cli/pack_config_registries_default/

## Solution

Added a post-generation step that walks the output directory and strips [ANSI escape sequences](https://blog.mbedded.ninja/programming/ansi-escape-sequences/) `(\x1b\[[0-9;]*m)` from all generated .md files. This is the appropriate place to handle the conversion (rather than changing the pack CLI output) — the generator is the boundary between terminal output and markdown, and stripping color codes there keeps the fix localized without affecting the upstream CLI's terminal experience. The fix also future-proofs the documentation against newly added CLI ANSI escape codes. 

Three generated markdown files were affected: `pack_config_pull-policy.md`, `pack_config_lifecycle-image.md`, and `pack_config_registries_default.md`. 

## Testing

- Verified which files this change touched by running a diff between the pack cli directory tree before and after the change. There were 3 touched files:

```
➜  docs git:(main) ✗ diff -r /tmp/pack-cli-before /home/lorenzo/projects/docs/content/docs/for-platform-operators/how-to/integrate-ci/pack/cli | cat -v
diff --color -r /tmp/pack-cli-before/pack_config_lifecycle-image.md /home/lorenzo/projects/docs/content/docs/for-platform-operators/how-to/integrate-ci/pack/cli/pack_config_lifecycle-image.md
23c23
<   -u, --unset   Unset custom lifecycle image, and use the lifecycle images from ^[[94mdocker.io/buildpacksio/lifecycle^[[0m
---
>   -u, --unset   Unset custom lifecycle image, and use the lifecycle images from docker.io/buildpacksio/lifecycle
diff --color -r /tmp/pack-cli-before/pack_config_pull-policy.md /home/lorenzo/projects/docs/content/docs/for-platform-operators/how-to/integrate-ci/pack/cli/pack_config_pull-policy.md
17c17
< Unsetting the pull policy will reset the policy to the default, which is ^[[94malways^[[0m
---
> Unsetting the pull policy will reset the policy to the default, which is always
27c27
<   -u, --unset   Unset pull policy, and set it back to the default pull-policy, which is ^[[94malways^[[0m
---
>   -u, --unset   Unset pull policy, and set it back to the default pull-policy, which is always
diff --color -r /tmp/pack-cli-before/pack_config_registries_default.md /home/lorenzo/projects/docs/content/docs/for-platform-operators/how-to/integrate-ci/pack/cli/pack_config_registries_default.md
18c18
< Unsetting the default registry will reset the default-registry to be the official buildpacks registry, ^[[94mhttps://github.com/buildpacks/registry-index^[[0m
---
> Unsetting the default registry will reset the default-registry to be the official buildpacks registry, https://github.com/buildpacks/registry-index
```

- Visually inspected the modified documentation pages with `make serve`